### PR TITLE
Add filler word breakdown metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ Example response:
   "raw_metrics": {
     "wpm": 165.2,
     "pitch": 230.5,
-    "filler_words": 3
+    "filler_words": 3,
+    "filler_word_total": 3,
+    "filler_word_breakdown": {
+      "um": 1,
+      "uh": 1,
+      "like": 1
+    }
   }
 }
 ```
-`wpm` is calculated from the transcript duration reported by Whisper, while `filler_words` counts common verbal fillers such as "um" or "like". `pitch` reports the median detected pitch of the audio in Hertz.
+`wpm` is calculated from the transcript duration reported by Whisper. `filler_words` and `filler_word_total` count verbal fillers, while `filler_word_breakdown` shows the usage of each filler. `pitch` reports the median detected pitch of the audio in Hertz.
 
 ## Error Handling
 If an error occurs, a JSON response with `error` is returned and the server logs the error to the console.


### PR DESCRIPTION
## Summary
- calculate filler word totals and breakdown in `getRawMetrics`
- expose `filler_word_total` and `filler_word_breakdown` via `/analyze`
- document new metrics in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850e9df275c8332b2acd56045e61dfe