### PR TITLE
Switch to gpt-4o-mini

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const upload = multer({ storage: multer.memoryStorage() });
 
 async function analyzeTranscript(transcript) {
   const completion = await openai.chat.completions.create({
-    model: 'gpt-3.5-turbo',
+    model: 'gpt-4o-mini',
     response_format: { type: 'json_object' },
     messages: [
       {


### PR DESCRIPTION
## Summary
- use `gpt-4o-mini` for tone analysis instead of `gpt-3.5-turbo`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850ed0e58808332bc0643d1800da954