### PR TITLE
Refine repetition detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example response:
     "pitch_variation": 32.1,
     "filler_words": 3,
     "filler_word_total": 3,
-    "repetitive_phrases": ["you know"],
+    "repetitive_phrases": ["i just want to"],
     "repetition_score": 1,
     "energy_score": 7,
     "energy_label": "Moderate",

--- a/index.js
+++ b/index.js
@@ -157,7 +157,18 @@ function detectRepetitions(transcript) {
       counts[phrase] = (counts[phrase] || 0) + 1;
     }
   }
-  const phrases = Object.keys(counts).filter(p => counts[p] > 1);
+
+  const repeated = Object.keys(counts)
+    .filter(p => counts[p] > 1)
+    .sort((a, b) => b.split(' ').length - a.split(' ').length);
+
+  const phrases = [];
+  for (const phrase of repeated) {
+    if (!phrases.some(longer => longer.includes(phrase))) {
+      phrases.push(phrase);
+    }
+  }
+
   return { phrases, score: phrases.length };
 }
 


### PR DESCRIPTION
## Summary
- remove sub-phrase duplicates when detecting repeated phrases
- update API example to show longest repetition only

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_68538bcf37988332a7cfe3fef409f1bf