### PR TITLE
Validate remote video inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ Example response:
 ## Error Handling
 If an error occurs, a JSON response with `error` is returned and the server logs the error to the console.
 
+## Remote Tone API
+
+`POST /api/tone/analyze` accepts a JSON body with a `videoUrl`. The URL must point directly to an MP4 file no larger than 25\u00A0MB.
+

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const upload = multer({ storage: multer.memoryStorage() });
 
+const MAX_VIDEO_SIZE = 25 * 1024 * 1024; // 25 MB
+
 async function analyzeTranscript(transcript, metrics = {}) {
   const metricParts = [];
   if (metrics.wpm) metricParts.push(`words per minute: ${metrics.wpm}`);
@@ -134,6 +136,24 @@ async function extractFrame(videoBuffer, timestamp) {
       resolve(Buffer.concat(chunks));
     });
     ff.stdin.end(videoBuffer);
+  });
+}
+
+async function validateVideo(buffer) {
+  return new Promise((resolve, reject) => {
+    const ff = spawn(ffmpegPath || 'ffmpeg', [
+      '-v', 'error',
+      '-i', 'pipe:0',
+      '-f', 'null',
+      '-'
+    ]);
+    ff.on('error', reject);
+    ff.on('close', code => {
+      if (code === 0) return resolve(true);
+      reject(new Error('Invalid media file'));
+    });
+    ff.stderr.resume();
+    ff.stdin.end(buffer);
   });
 }
 
@@ -357,11 +377,32 @@ app.post('/api/tone/analyze', async (req, res, next) => {
   let videoBuffer;
   try {
     const resp = await fetch(videoUrl);
+    console.log('Fetch status:', resp.status);
+    console.log('Content-Type:', resp.headers.get('content-type'));
+    console.log('Content-Length:', resp.headers.get('content-length'));
     if (!resp.ok) throw new Error('Failed to fetch video');
+    const type = resp.headers.get('content-type') || '';
+    if (!type.startsWith('video/') && !type.startsWith('audio/')) {
+      return res.status(400).json({ error: 'URL must point to a video or audio file' });
+    }
+    const lenHeader = resp.headers.get('content-length');
+    if (lenHeader && parseInt(lenHeader, 10) > MAX_VIDEO_SIZE) {
+      return res.status(400).json({ error: 'Video must be under 25MB' });
+    }
     videoBuffer = Buffer.from(await resp.arrayBuffer());
+    if (videoBuffer.length > MAX_VIDEO_SIZE) {
+      return res.status(400).json({ error: 'Video must be under 25MB' });
+    }
   } catch (err) {
     console.error('Video download error:', err);
     return next(new Error('Failed to download video'));
+  }
+
+  try {
+    await validateVideo(videoBuffer);
+  } catch (err) {
+    console.error('Video validation error:', err);
+    return res.status(400).json({ error: 'Invalid or unsupported video file' });
   }
 
   const result = {


### PR DESCRIPTION
## Summary
- log fetch response details for `/api/tone/analyze`
- reject remote videos if not audio/video or larger than 25MB
- add ffmpeg-based media validation helper
- return a 400 error for invalid media
- document remote API requirements

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855c78eefcc83329b92c623b71a1e75