### PR TITLE
Remove File polyfill and simplify Whisper requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,14 @@ import express from 'express';
 import multer from 'multer';
 import dotenv from 'dotenv';
 import OpenAI from 'openai';
-import { File as NodeFile } from 'node:buffer';
 import { spawn } from 'child_process';
 import ffmpegPath from 'ffmpeg-static';
 import { YIN } from 'pitchfinder';
 
 dotenv.config();
 
-if (typeof globalThis.File === 'undefined') {
-  globalThis.File = NodeFile;
+if (!process.env.OPENAI_API_KEY) {
+  console.warn('Warning: OPENAI_API_KEY environment variable is missing');
 }
 
 const app = express();
@@ -264,6 +263,10 @@ async function getRawMetrics(transcript, segments = [], audioBuffer) {
   };
 }
 
+app.get('/health', (req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
 app.post('/analyze', upload.single('video'), async (req, res, next) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No video file provided' });
@@ -281,9 +284,8 @@ app.post('/analyze', upload.single('video'), async (req, res, next) => {
 
   let segments = [];
   try {
-    const file = await OpenAI.toFile(req.file.buffer, req.file.originalname);
     const transcription = await openai.audio.transcriptions.create({
-      file,
+      file: req.file.buffer,
       model: 'whisper-1',
       response_format: 'verbose_json'
     });


### PR DESCRIPTION
## Summary
- drop Node `File` polyfill check
- warn when `OPENAI_API_KEY` isn't set
- expose `/health` endpoint
- send raw buffers to OpenAI Whisper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68562949ccac8332a8462d08512d84a8